### PR TITLE
More TODO tags, TODO type, strict comment matching

### DIFF
--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -22,17 +22,22 @@ class ToDoView
     title.classList.add('title')
     @element.appendChild(title)
     master = document.createElement('div')
+    currentEditor = atom.workspace.getActiveTextEditor()
 
     runList = (text) ->
       message = document.createElement('div')
-      textSpan = document.createElement('span')
-      # checkbox = document.createElement('input')
-      # checkbox.type = "checkbox"
-      textSpan.textContent = text   #textSpan.textContent = " " + text
+      textButton = document.createElement('span')
+
+      gotoTodo = () ->
+        currentEditor.setCursorBufferPosition([text[0], 0])
+
+      textButton.type = 'button'
+      textButton.textContent = text[1]
+      textButton.onclick = gotoTodo
+
       message.classList.add('todoItem')
-      #message.appendChild(checkbox)
-      message.appendChild(textSpan)
-      #console.log(master)
+      message.appendChild(textButton)
+
       master.appendChild(message)
 
     runList(x) for x in todoItem

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -37,8 +37,10 @@ class ToDoView
           tag = currentEditor.getTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]])
           if tag == 'DONE:'
             currentEditor.setTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]], '')
+            todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
           else
             currentEditor.insertText('DONE:')
+            todoText.textContent = "DONE:#{text[2]}: Line #{text[0]}: #{text[3]}"
 
       todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
 

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -29,10 +29,10 @@ class ToDoView
       textButton = document.createElement('span')
 
       gotoTodo = () ->
-        currentEditor.setCursorBufferPosition([text[0], 0])
+        currentEditor.setCursorBufferPosition([text[0]-1, text[1]+1])
 
       textButton.type = 'button'
-      textButton.textContent = text[1]
+      textButton.textContent = text[2]
       textButton.onclick = gotoTodo
 
       message.classList.add('todoItem')

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -41,6 +41,7 @@ class ToDoView
           todoText.textContent = "DONE:#{todo[2]}: Line #{todo[0]}: #{todo[3]}"
 
       todoText.textContent = "#{todo[2]}: Line #{todo[0]}: #{todo[3]}"
+      todo[2] = todo[2].replace(/^DONE\:/, "") unless todo[2] == 'DONE:'
 
       message.classList.add('todoItem')
       message.appendChild(todoText)

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -29,7 +29,17 @@ class ToDoView
       todoText = document.createElement('span')
 
       message.type = 'button'
-      message.onclick = gotoTodo = () -> currentEditor.setCursorBufferPosition([text[0]-1, text[1]+text[2].length])
+      message.onclick = () ->
+        cursor = currentEditor.getCursorBufferPosition()
+        currentEditor.setCursorBufferPosition([text[0]-1, text[1]+text[2].length])
+        if cursor.row == text[0] - 1
+          currentEditor.moveLeft(text[2].length)
+          tag = currentEditor.getTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]])
+          if tag == 'DONE:'
+            currentEditor.setTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]], '')
+          else
+            currentEditor.insertText('DONE:')
+
       todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
 
       message.classList.add('todoItem')

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -30,7 +30,7 @@ class ToDoView
 
       message.type = 'button'
       message.onclick = () ->
-        currentEditor.setCursorBufferPosition([todo[0]-1, todo[1]+todo[2].length])
+        currentEditor.setCursorBufferPosition([todo[0]-1, todo[1]+todo[2].length+1])
       message.ondblclick = () ->
         currentEditor.setCursorBufferPosition([todo[0]-1, todo[1]])
         if currentEditor.getTextInBufferRange([[todo[0]-1, todo[1]], [todo[0]-1, todo[1]+5]]) == 'DONE:'

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -27,20 +27,21 @@ class ToDoView
     runList = (todo) ->
       message = document.createElement('div')
       todoText = document.createElement('span')
+      text = "#{todo[2]}: Line #{todo[0]+1}: #{todo[3]}"
 
       message.type = 'button'
       message.onclick = () ->
-        currentEditor.setCursorBufferPosition([todo[0]-1, todo[1]+todo[2].length+1])
+        currentEditor.setCursorBufferPosition([todo[0], todo[1]+todo[2].length+1])
       message.ondblclick = () ->
-        currentEditor.setCursorBufferPosition([todo[0]-1, todo[1]])
-        if currentEditor.getTextInBufferRange([[todo[0]-1, todo[1]], [todo[0]-1, todo[1]+5]]) == 'DONE:'
-          currentEditor.setTextInBufferRange([[todo[0]-1, todo[1]], [todo[0]-1, todo[1]+5]], '')
-          todoText.textContent = "#{todo[2]}: Line #{todo[0]}: #{todo[3]}"
+        currentEditor.setCursorBufferPosition([todo[0], todo[1]])
+        if currentEditor.getTextInBufferRange([[todo[0], todo[1]], [todo[0], todo[1]+5]]) == 'DONE:'
+          currentEditor.setTextInBufferRange([[todo[0], todo[1]], [todo[0], todo[1]+5]], '')
+          todoText.textContent = text
         else
           currentEditor.insertText('DONE:')
-          todoText.textContent = "DONE:#{todo[2]}: Line #{todo[0]}: #{todo[3]}"
+          todoText.textContent = "DONE:#{text}"
 
-      todoText.textContent = "#{todo[2]}: Line #{todo[0]}: #{todo[3]}"
+      todoText.textContent = text
       todo[2] = todo[2].replace(/^DONE\:/, "") unless todo[2] == 'DONE:'
 
       message.classList.add('todoItem')

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -26,17 +26,14 @@ class ToDoView
 
     runList = (text) ->
       message = document.createElement('div')
-      textButton = document.createElement('span')
+      todoText = document.createElement('span')
 
-      gotoTodo = () ->
-        currentEditor.setCursorBufferPosition([text[0]-1, text[1]+1])
-
-      textButton.type = 'button'
-      textButton.textContent = text[2]
-      textButton.onclick = gotoTodo
+      message.type = 'button'
+      message.onclick = gotoTodo = () -> currentEditor.setCursorBufferPosition([text[0]-1, text[1]+text[2].length])
+      todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
 
       message.classList.add('todoItem')
-      message.appendChild(textButton)
+      message.appendChild(todoText)
 
       master.appendChild(message)
 

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -24,23 +24,23 @@ class ToDoView
     master = document.createElement('div')
     currentEditor = atom.workspace.getActiveTextEditor()
 
-    runList = (text) ->
+    runList = (todo) ->
       message = document.createElement('div')
       todoText = document.createElement('span')
 
       message.type = 'button'
       message.onclick = () ->
-        currentEditor.setCursorBufferPosition([text[0]-1, text[1]+text[2].length])
+        currentEditor.setCursorBufferPosition([todo[0]-1, todo[1]+todo[2].length])
       message.ondblclick = () ->
-        currentEditor.setCursorBufferPosition([text[0]-1, text[1]])
-        if currentEditor.getTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]]) == 'DONE:'
-          currentEditor.setTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]], '')
-          todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
+        currentEditor.setCursorBufferPosition([todo[0]-1, todo[1]])
+        if currentEditor.getTextInBufferRange([[todo[0]-1, todo[1]], [todo[0]-1, todo[1]+5]]) == 'DONE:'
+          currentEditor.setTextInBufferRange([[todo[0]-1, todo[1]], [todo[0]-1, todo[1]+5]], '')
+          todoText.textContent = "#{todo[2]}: Line #{todo[0]}: #{todo[3]}"
         else
           currentEditor.insertText('DONE:')
-          todoText.textContent = "DONE:#{text[2]}: Line #{text[0]}: #{text[3]}"
+          todoText.textContent = "DONE:#{todo[2]}: Line #{todo[0]}: #{todo[3]}"
 
-      todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
+      todoText.textContent = "#{todo[2]}: Line #{todo[0]}: #{todo[3]}"
 
       message.classList.add('todoItem')
       message.appendChild(todoText)

--- a/lib/to-do-view.coffee
+++ b/lib/to-do-view.coffee
@@ -30,17 +30,15 @@ class ToDoView
 
       message.type = 'button'
       message.onclick = () ->
-        cursor = currentEditor.getCursorBufferPosition()
         currentEditor.setCursorBufferPosition([text[0]-1, text[1]+text[2].length])
-        if cursor.row == text[0] - 1
-          currentEditor.moveLeft(text[2].length)
-          tag = currentEditor.getTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]])
-          if tag == 'DONE:'
-            currentEditor.setTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]], '')
-            todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
-          else
-            currentEditor.insertText('DONE:')
-            todoText.textContent = "DONE:#{text[2]}: Line #{text[0]}: #{text[3]}"
+      message.ondblclick = () ->
+        currentEditor.setCursorBufferPosition([text[0]-1, text[1]])
+        if currentEditor.getTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]]) == 'DONE:'
+          currentEditor.setTextInBufferRange([[text[0]-1, text[1]], [text[0]-1, text[1]+5]], '')
+          todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
+        else
+          currentEditor.insertText('DONE:')
+          todoText.textContent = "DONE:#{text[2]}: Line #{text[0]}: #{text[3]}"
 
       todoText.textContent = "#{text[2]}: Line #{text[0]}: #{text[3]}"
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -58,7 +58,7 @@ module.exports = ToDo =
       # Check if current line is not empty and is a comment
       if not todoText
         return
-      else if not currentEditor.isBufferRowCommented(ln-1)
+      else if not currentEditor.isBufferRowCommented(ln)
         return
 
       # Search for all possible TODOs tags
@@ -77,7 +77,7 @@ module.exports = ToDo =
         allTodos.push [ln, idx, todoType, todoText]
 
     # Check each line of the buffer
-    createTodoList(x+1, currentEditor.lineTextForBufferRow(x)) for x in [0..currentEditor.getLineCount()]
+    createTodoList(x, currentEditor.lineTextForBufferRow(x)) for x in [0..currentEditor.getLineCount()]
 
     # Sort by type then line
     allTodos.sort (a,b) ->

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -40,7 +40,7 @@ module.exports = ToDo =
       when ".source.python", ".source.yaml"
         ['(#|"""|\'\'\')', '(|"""|\'\'\')']
       when ".source.coffee"
-        ['#{1,3}', '#{0,3}']
+        ['(###|#)', '(###|)']
       when ".source.cpp", ".source.c", ".source.js", ".source.go"
         ['(//|/\\*)', '(|\\*/)']
       when ".source.haskell"

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -36,17 +36,19 @@ module.exports = ToDo =
     # declare opening and closing comment keywords
     reComment = switch currentScope
       when ".source.gfm", ".source.html", ".source.css", ".source.css.less"
-        ["<!--", "-->"]
-      when ".source.python", ".source.coffee", ".source.shell", ".source.yaml"
-        ["#", ""]
+        ['<!--', '-->']
+      when ".source.python"
+        ['(#|"""|\'\'\')', '(|"""|\'\'\')']
+      when ".source.coffee", ".source.shell", ".source.yaml"
+        ['#', '']
       when ".source.cpp", ".source.c", ".source.js", ".source.go"
-        ["(//|/\\*)", "(|\\*/)"]
+        ['(//|/\\*)', '(|\\*/)']
       when ".source.haskell"
-        ["--", ""]
+        ['--', '']
       when ".source.php", ".text.html.php"
-        ["(#|//|<!--)", "(|-->)"]
+        ['(#|//|<!--)', '(|-->)']
       else
-        [".*", ".*"]
+        ['.*', '.*']
 
     createTodoList = (ln, todoText) ->
       # Search for all possible TODOs tags

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -68,7 +68,7 @@ module.exports = ToDo =
         # get TODO text
         todoText = todoText.replace(///\s*#{todoTags}[:;.,]?\s*///, "") unless reComment[0] == ".*"
 
-        allTodos.push "#{todoType}: Line #{ln}: #{todoText}"
+        allTodos.push [ln, "#{todoType}: Line #{ln}: #{todoText}"]
 
     createTodoList(x+1, currentEditor.lineTextForBufferRow(x)) for x in [0..currentEditor.getLineCount()]
 
@@ -77,7 +77,7 @@ module.exports = ToDo =
     else
       # sort by type then line
       allTodos.sort (a,b) ->
-        return (a > b)
+        return (a[1] > b[1])
       @toDoView.setTodos(allTodos)
       @modalPanel.show()
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -42,7 +42,6 @@ module.exports = ToDo =
         todoText = todoText.replace(/(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/, "")
         todoText = todoText.replace(/^\s+|\s+$/, "")
         todoText = todoText.replace(/#/, "")
-        todoText = todoText.replace(/\/*/, "")
         todoText = todoText.replace(/<!--/, "")
         todoText = todoText.replace(/-->/, "")
         todoText = todoText.replace(/\/\//, "")

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -47,6 +47,7 @@ module.exports = ToDo =
         todoText = todoText.replace(/^\/\//, "")          # C++ single line comment
         todoText = todoText.replace(/(^\/\*|\*\/$)/g, "") # C++ multiline comment
         todoText = todoText.replace(/(^<!--|-->$)/g, "")  # html comment
+        todoText = todoText.replace(/^--/, "")            # Haskell comment
         todoText = todoText.replace(/(^\s+|\s+)$/g, "")   # strip spaces
 
         # push TODOs type, line and text

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -40,11 +40,14 @@ module.exports = ToDo =
 
         # get TODOs text
         todoText = todoText.replace(/(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/, "")
-        todoText = todoText.replace(/^\s+|\s+$/, "")
-        todoText = todoText.replace(/#/, "")
-        todoText = todoText.replace(/<!--/, "")
-        todoText = todoText.replace(/-->/, "")
-        todoText = todoText.replace(/\/\//, "")
+        todoText = todoText.replace(/^\s+|\s+$/, "")       # strip spaces
+        todoText = todoText.replace(/^#+/, "")             # hashtag comment (Python, CoffeeScript, shell, etc...)
+        todoText = todoText.replace(/^\"\"\"|\"\"\"$/, "") # Python multiline comment 1
+        todoText = todoText.replace(/^\'\'\'|\'\'\'$/, "") # Python multiline comment 2
+        todoText = todoText.replace(/^\/\//, "")           # C++ single line comment
+        todoText = todoText.replace(/^\/\*|\*\/$/, "")     # C++ multiline comment
+        todoText = todoText.replace(/^<!--|-->$/, "")      # html comment
+        todoText = todoText.replace(/^\s+|\s+$/, "")       # strip spaces
 
         # push TODOs type, line and text
         allTodos.push todoType + ': ' + 'Line ' + ln + ': ' + todoText

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -31,9 +31,9 @@ module.exports = ToDo =
     currentEditor = atom.workspace.getActiveTextEditor()
     allTodos = []
     createTodoList = (ln, todoText) ->
-      containsTODO = /TODO:/.test(todoText)
+      containsTODO = /(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/.test(todoText)
       if containsTODO
-        todoText = todoText.replace(/TODO:/, "")
+        todoText = todoText.replace(/(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/, "")
         todoText = todoText.replace(/^\s+|\s+$/, "")
         todoText = todoText.replace(/#/, "")
         todoText = todoText.replace(/\/*/, "")

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -40,14 +40,14 @@ module.exports = ToDo =
 
         # get TODOs text
         todoText = todoText.replace(/(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/, "")
-        todoText = todoText.replace(/^\s+|\s+$/, "")       # strip spaces
-        todoText = todoText.replace(/^#+/, "")             # hashtag comment (Python, CoffeeScript, shell, etc...)
-        todoText = todoText.replace(/^\"\"\"|\"\"\"$/, "") # Python multiline comment 1
-        todoText = todoText.replace(/^\'\'\'|\'\'\'$/, "") # Python multiline comment 2
-        todoText = todoText.replace(/^\/\//, "")           # C++ single line comment
-        todoText = todoText.replace(/^\/\*|\*\/$/, "")     # C++ multiline comment
-        todoText = todoText.replace(/^<!--|-->$/, "")      # html comment
-        todoText = todoText.replace(/^\s+|\s+$/, "")       # strip spaces
+        todoText = todoText.replace(/(^\s+|\s+$)/g, "")   # strip spaces
+        todoText = todoText.replace(/^#+/, "")            # hashtag comment (Python, CoffeeScript, shell, etc...)
+        todoText = todoText.replace(/(^"""|"""$)/g, "")   # Python multiline comment 1
+        todoText = todoText.replace(/(^'''|'''$)/g, "")   # Python multiline comment 2
+        todoText = todoText.replace(/^\/\//, "")          # C++ single line comment
+        todoText = todoText.replace(/(^\/\*|\*\/$)/g, "") # C++ multiline comment
+        todoText = todoText.replace(/(^<!--|-->$)/g, "")  # html comment
+        todoText = todoText.replace(/(^\s+|\s+)$/g, "")   # strip spaces
 
         # push TODOs type, line and text
         allTodos.push todoType + ': ' + 'Line ' + ln + ': ' + todoText

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -57,11 +57,11 @@ module.exports = ToDo =
     createTodoList = (ln, todoText) ->
       # Search for all possible TODOs tags
       if ///^\s*#{reComment[0]}\s*#{todoTags}[:;.,]?.+#{reComment[1]}\s*$///.test(todoText)
+        # get TODO index
+        idx = todoText.search(///#{todoTags}///)
+
         # get TODO type
         todoType = todoText.match(///#{todoTags}///)[0]
-
-        # get TODO index
-        todoIndex = todoText.search(///#{todoTags}///) + todoType.length
 
         # strip and remove comment keywords
         todoText = todoText.replace(/(^\s+|\s+$)/g, "")
@@ -71,7 +71,7 @@ module.exports = ToDo =
         # get TODO text
         todoText = todoText.replace(///\s*#{todoTags}[:;.,]?\s*///, "") unless reComment[0] == ".*"
 
-        allTodos.push [ln, todoIndex, "#{todoType}: Line #{ln}: #{todoText}"]
+        allTodos.push [ln, idx, todoType, todoText]
 
     createTodoList(x+1, currentEditor.lineTextForBufferRow(x)) for x in [0..currentEditor.getLineCount()]
 
@@ -80,7 +80,7 @@ module.exports = ToDo =
     else
       # sort by type then line
       allTodos.sort (a,b) ->
-        return (a[2] > b[2])
+        return (a[2] + a[0] > b[2] + b[0])
       @toDoView.setTodos(allTodos)
       @modalPanel.show()
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -40,7 +40,7 @@ module.exports = ToDo =
       when ".source.python"
         ['(#|"""|\'\'\')', '(|"""|\'\'\')']
       when ".source.coffee", ".source.shell", ".source.yaml"
-        ['#', '']
+        ['#{1,3}', '#{0,3}']
       when ".source.cpp", ".source.c", ".source.js", ".source.go"
         ['(//|/\\*)', '(|\\*/)']
       when ".source.haskell"

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -39,7 +39,7 @@ module.exports = ToDo =
         ['<!--', '-->']
       when ".source.python", ".source.yaml"
         ['(#|"""|\'\'\')', '(|"""|\'\'\')']
-      when ".source.coffee", ".source.shell"
+      when ".source.coffee"
         ['#{1,3}', '#{0,3}']
       when ".source.cpp", ".source.c", ".source.js", ".source.go"
         ['(//|/\\*)', '(|\\*/)']
@@ -47,6 +47,8 @@ module.exports = ToDo =
         ['--', '']
       when ".source.php", ".text.html.php"
         ['(#|//|<!--)', '(|-->)']
+      when ".source.shell"
+        ['#', '']
       else
         ['.*', '.*']
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -28,6 +28,11 @@ module.exports = ToDo =
     toDoViewState: @toDoView.serialize()
 
   toggle: ->
+    # close panel and exit if toggling it off
+    if @modalPanel.isVisible()
+      @modalPanel.hide()
+      return
+
     currentEditor = atom.workspace.getActiveTextEditor()
     currentScope = currentEditor.getRootScopeDescriptor().toString()
     todoTags = "(DONE:|)(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)"
@@ -67,16 +72,16 @@ module.exports = ToDo =
 
         allTodos.push [ln, idx, todoType, todoText]
 
+    # check each line of the buffer
     createTodoList(x+1, currentEditor.lineTextForBufferRow(x)) for x in [0..currentEditor.getLineCount()]
 
-    if @modalPanel.isVisible()
-      @modalPanel.hide()
-    else
-      # sort by type then line
-      allTodos.sort (a,b) ->
-        return (a[2] + a[0] > b[2] + b[0])
-      @toDoView.setTodos(allTodos)
-      @modalPanel.show()
+    # sort by type then line
+    allTodos.sort (a,b) ->
+      return (a[2] + a[0] > b[2] + b[0])
+
+    # save TODOs and show panel
+    @toDoView.setTodos(allTodos)
+    @modalPanel.show()
 
   saved: ->
     #console.log 'yo yo yo'

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -47,6 +47,10 @@ module.exports = ToDo =
         ['--', '']
       when ".source.php", ".text.html.php"
         ['(#|//|<!--)', '(|-->)']
+      when ".source.rust"
+        ['//', '']
+      when ".source.ruby"
+        ['(=begin|#)', '(=end|)']
       when ".source.shell"
         ['#', '']
       else

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -57,6 +57,9 @@ module.exports = ToDo =
     if @modalPanel.isVisible()
       @modalPanel.hide()
     else
+      # sort by type then line
+      allTodos.sort (a,b) ->
+        return (a > b)
       @toDoView.setTodos(allTodos)
       @modalPanel.show()
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -81,7 +81,7 @@ module.exports = ToDo =
 
     # Sort by type then line
     allTodos.sort (a,b) ->
-      return (a[2] + a[0] > b[2] + b[0])
+      return (a[2] > b[2])
 
     # Save TODOs and show panel
     @toDoView.setTodos(allTodos)

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -40,7 +40,7 @@ module.exports = ToDo =
       when ".source.python", ".source.coffee", ".source.shell", ".source.yaml"
         ["#", ""]
       when ".source.cpp", ".source.c", ".source.js", ".source.go"
-        ["//", ""]
+        ["(//|/\\*)", "(|\\*/)"]
       when ".source.haskell"
         ["--", ""]
       when ".source.php", ".text.html.php"

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -62,7 +62,7 @@ module.exports = ToDo =
         return
 
       # Search for all possible TODOs tags
-      if ///#{todoTags}[:;.,].+///.test(todoText)
+      if ///#{todoTags}[:;.,]\s*[^\s]///.test(todoText)
         # Get TODO index
         idx = todoText.search(///#{todoTags}///)
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -34,18 +34,19 @@ module.exports = ToDo =
     allTodos = []
 
     # declare opening and closing comment keywords
-    if currentScope in [".source.gfm", ".source.html", ".source.css", ".source.css.less"]
-      reComment = ["<!--", "-->"]
-    else if currentScope in [".source.python", ".source.coffee", ".source.shell", ".source.yaml"]
-      reComment = ["#", ""]
-    else if currentScope == ".source.haskell"
-      reComment = ["--", ""]
-    else if currentScope in [".source.cpp", ".source.c", ".source.js", ".source.go"]
-      reComment = ["//", ""]
-    else if currentScope in ['.source.php', '.text.html.php']
-      reComment = ["(#|//|<!--)", "(|-->)"]
-    else
-      reComment = [".*", ".*"]
+    reComment = switch currentScope
+      when ".source.gfm", ".source.html", ".source.css", ".source.css.less"
+        ["<!--", "-->"]
+      when ".source.python", ".source.coffee", ".source.shell", ".source.yaml"
+        ["#", ""]
+      when ".source.cpp", ".source.c", ".source.js", ".source.go"
+        ["//", ""]
+      when ".source.haskell"
+        ["--", ""]
+      when ".source.php", ".text.html.php"
+        ["(#|//|<!--)", "(|-->)"]
+      else
+        [".*", ".*"]
 
     createTodoList = (ln, todoText) ->
       # Search for all possible TODOs tags

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -30,7 +30,7 @@ module.exports = ToDo =
   toggle: ->
     currentEditor = atom.workspace.getActiveTextEditor()
     currentScope = currentEditor.getRootScopeDescriptor().toString()
-    todoTags = "(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)"
+    todoTags = "(DONE:|)(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)"
     allTodos = []
 
     # declare opening and closing comment keywords

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -49,9 +49,7 @@ module.exports = ToDo =
         ['(#|//|<!--)', '(|-->)']
       when ".source.rust"
         ['//', '']
-      when ".source.ruby"
-        ['(=begin|#)', '(=end|)']
-      when ".source.shell"
+      when ".source.shell", ".source.ruby"
         ['#', '']
       else
         ['.*', '.*']

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -57,18 +57,21 @@ module.exports = ToDo =
     createTodoList = (ln, todoText) ->
       # Search for all possible TODOs tags
       if ///^\s*#{reComment[0]}\s*#{todoTags}[:;.,]?.+#{reComment[1]}\s*$///.test(todoText)
+        # get TODO type
+        todoType = todoText.match(///#{todoTags}///)[0]
+
+        # get TODO index
+        todoIndex = todoText.search(///#{todoTags}///) + todoType.length
+
         # strip and remove comment keywords
         todoText = todoText.replace(/(^\s+|\s+$)/g, "")
         todoText = todoText.replace(///^#{reComment[0]}\s*///, "") unless reComment[0] == ".*"
         todoText = todoText.replace(///\s*#{reComment[1]}$///, "") unless reComment[1] == ".*"
 
-        # get TODO type
-        todoType = todoText.match(///#{todoTags}///)[0]
-
         # get TODO text
         todoText = todoText.replace(///\s*#{todoTags}[:;.,]?\s*///, "") unless reComment[0] == ".*"
 
-        allTodos.push [ln, "#{todoType}: Line #{ln}: #{todoText}"]
+        allTodos.push [ln, todoIndex, "#{todoType}: Line #{ln}: #{todoText}"]
 
     createTodoList(x+1, currentEditor.lineTextForBufferRow(x)) for x in [0..currentEditor.getLineCount()]
 
@@ -77,7 +80,7 @@ module.exports = ToDo =
     else
       # sort by type then line
       allTodos.sort (a,b) ->
-        return (a[1] > b[1])
+        return (a[2] > b[2])
       @toDoView.setTodos(allTodos)
       @modalPanel.show()
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -31,10 +31,14 @@ module.exports = ToDo =
     currentEditor = atom.workspace.getActiveTextEditor()
     allTodos = []
     createTodoList = (ln, todoText) ->
+      # Search for all possible TODOs tags
       containsTODO = /(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/.test(todoText)
       if containsTODO
+        # get TODOs type
         todoType = todoText.match(/(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/)[0]
         todoType = todoType.replace(/[:;.,]$/, "")
+
+        # get TODOs text
         todoText = todoText.replace(/(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/, "")
         todoText = todoText.replace(/^\s+|\s+$/, "")
         todoText = todoText.replace(/#/, "")
@@ -42,6 +46,8 @@ module.exports = ToDo =
         todoText = todoText.replace(/<!--/, "")
         todoText = todoText.replace(/-->/, "")
         todoText = todoText.replace(/\/\//, "")
+
+        # push TODOs type, line and text
         allTodos.push todoType + ': ' + 'Line ' + ln + ': ' + todoText
 
     createTodoList(x+1, currentEditor.lineTextForBufferRow(x)) for x in [0..currentEditor.getLineCount()]

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -42,6 +42,8 @@ module.exports = ToDo =
       reComment = ["--", ""]
     else if currentScope in [".source.cpp", ".source.c", ".source.js", ".source.go"]
       reComment = ["//", ""]
+    else if currentScope in ['.source.php', '.text.html.php']
+      reComment = ["(#|//|<!--)", "(|-->)"]
     else
       reComment = [".*", ".*"]
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -33,6 +33,8 @@ module.exports = ToDo =
     createTodoList = (ln, todoText) ->
       containsTODO = /(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/.test(todoText)
       if containsTODO
+        todoType = todoText.match(/(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/)[0]
+        todoType = todoType.replace(/[:;.,]$/, "")
         todoText = todoText.replace(/(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)[:;.,]?/, "")
         todoText = todoText.replace(/^\s+|\s+$/, "")
         todoText = todoText.replace(/#/, "")
@@ -40,7 +42,7 @@ module.exports = ToDo =
         todoText = todoText.replace(/<!--/, "")
         todoText = todoText.replace(/-->/, "")
         todoText = todoText.replace(/\/\//, "")
-        allTodos.push 'Line '+ln + ': ' + todoText
+        allTodos.push todoType + ': ' + 'Line ' + ln + ': ' + todoText
 
     createTodoList(x+1, currentEditor.lineTextForBufferRow(x)) for x in [0..currentEditor.getLineCount()]
 

--- a/lib/to-do.coffee
+++ b/lib/to-do.coffee
@@ -37,9 +37,9 @@ module.exports = ToDo =
     reComment = switch currentScope
       when ".source.gfm", ".source.html", ".source.css", ".source.css.less"
         ['<!--', '-->']
-      when ".source.python"
+      when ".source.python", ".source.yaml"
         ['(#|"""|\'\'\')', '(|"""|\'\'\')']
-      when ".source.coffee", ".source.shell", ".source.yaml"
+      when ".source.coffee", ".source.shell"
         ['#{1,3}', '#{0,3}']
       when ".source.cpp", ".source.c", ".source.js", ".source.go"
         ['(//|/\\*)', '(|\\*/)']


### PR DESCRIPTION
Add support for the following TODO tags: TODO, FIXME, CHANGED, XXX, IDEA, HACK, NOTE, REVIEW, NB, BUG, QUESTION, COMBAK, TEMP, DEBUG, OPTIMIZE, WARNING

Comment type (TODO, FIXME, etc...) is extracted and printed separately from the TODO text.

Allow to use slash `/` in TODO text (e.g. paths)

Strip comment keywords of the following types:
* `//` C++ single line comments
* `/*` `*/` C++ multiline comments
* `#` Python, CoffeeScript, etc.. single line comment
* `"""` `''''` Python multiline comment

Sort TODOs list before printing it. Sorting is done comparing the strings and thus by type, then line.